### PR TITLE
add option to disable in table text foster parenting

### DIFF
--- a/src/main/java/ch/digitalfondue/jfiveparse/Option.java
+++ b/src/main/java/ch/digitalfondue/jfiveparse/Option.java
@@ -93,4 +93,6 @@ public enum Option {
      * When encountering unknown self-closing tag, will interpret as self-closing tag instead of ignoring.
      */
     INTERPRET_SELF_CLOSING_ANYTHING_ELSE,
+
+    DISABLE_IN_TABLE_TEXT_FOSTER_PARENTING
 }

--- a/src/main/java/ch/digitalfondue/jfiveparse/Parser.java
+++ b/src/main/java/ch/digitalfondue/jfiveparse/Parser.java
@@ -29,6 +29,7 @@ public class Parser {
     private final boolean transformEntities;
     private final boolean disableIgnoreTokenInBodyStartTag;
     private final boolean interpretSelfClosingAnythingElse;
+    private final boolean disableInTableTextForsterParenting;
 
     /**
      * Instantiate a parser with the default configuration.
@@ -42,6 +43,7 @@ public class Parser {
         transformEntities = true;
         disableIgnoreTokenInBodyStartTag = false;
         interpretSelfClosingAnythingElse = false;
+        disableInTableTextForsterParenting = false;
     }
 
     /**
@@ -52,6 +54,7 @@ public class Parser {
      * <li>{@link Option#DONT_TRANSFORM_ENTITIES}</li>
      * <li>{@link Option#DISABLE_IGNORE_TOKEN_IN_BODY_START_TAG}</li>
      * <li>{@link Option#INTERPRET_SELF_CLOSING_ANYTHING_ELSE}</li>
+     * <li>{@link Option#DISABLE_IN_TABLE_TEXT_FOSTER_PARENTING}</li>
      * </ul>
      * 
      * @param options
@@ -61,6 +64,7 @@ public class Parser {
         this.transformEntities = !options.contains(Option.DONT_TRANSFORM_ENTITIES);
         this.disableIgnoreTokenInBodyStartTag = options.contains(Option.DISABLE_IGNORE_TOKEN_IN_BODY_START_TAG);
         this.interpretSelfClosingAnythingElse = options.contains(Option.INTERPRET_SELF_CLOSING_ANYTHING_ELSE);
+        this.disableInTableTextForsterParenting = options.contains(Option.DISABLE_IN_TABLE_TEXT_FOSTER_PARENTING);
     }
 
     /**
@@ -115,7 +119,7 @@ public class Parser {
 
         // 1 when creating a tree constructor, a document is automatically
         // created (good idea? y/n?)
-        TreeConstructor tokenHandler = new TreeConstructor(disableIgnoreTokenInBodyStartTag, interpretSelfClosingAnythingElse);
+        TreeConstructor tokenHandler = new TreeConstructor(disableIgnoreTokenInBodyStartTag, interpretSelfClosingAnythingElse , disableInTableTextForsterParenting);
         //
         tokenHandler.isHtmlFragmentParsing = true;
         tokenHandler.scriptingFlag = scriptingFlag;
@@ -187,7 +191,11 @@ public class Parser {
     }
 
     private Document parse(ProcessedInputStream is) {
-        TreeConstructor tokenHandler = new TreeConstructor(disableIgnoreTokenInBodyStartTag, interpretSelfClosingAnythingElse);
+        TreeConstructor tokenHandler = new TreeConstructor(
+                disableIgnoreTokenInBodyStartTag,
+                interpretSelfClosingAnythingElse,
+                disableInTableTextForsterParenting
+        );
         tokenHandler.scriptingFlag = scriptingFlag;
         Tokenizer tokenizer = new Tokenizer(tokenHandler, transformEntities);
         tokenHandler.setTokenizer(tokenizer);

--- a/src/main/java/ch/digitalfondue/jfiveparse/TreeConstructor.java
+++ b/src/main/java/ch/digitalfondue/jfiveparse/TreeConstructor.java
@@ -53,6 +53,7 @@ class TreeConstructor {
 
     final boolean disableIgnoreTokenInBodyStartTag;
     final boolean interpretSelfClosingAnythingElse;
+    final boolean disableInTableTextForsterParenting;
 
     // ----
     private int tokenType;
@@ -107,9 +108,10 @@ class TreeConstructor {
         this.tokenizer = tokenizer;
     }
 
-    TreeConstructor(boolean disableIgnoreTokenInBodyStartTag, boolean interpretSelfClosingAnythingElse) {
+    TreeConstructor(boolean disableIgnoreTokenInBodyStartTag, boolean interpretSelfClosingAnythingElse, boolean disableInTableTextForsterParenting) {
         this.disableIgnoreTokenInBodyStartTag = disableIgnoreTokenInBodyStartTag;
         this.interpretSelfClosingAnythingElse = interpretSelfClosingAnythingElse;
+        this.disableInTableTextForsterParenting = disableInTableTextForsterParenting;
     }
 
     private void setTagNameAndSaveOriginal(ResizableCharBuilder rawTagName) {

--- a/src/main/java/ch/digitalfondue/jfiveparse/TreeConstructorInTable.java
+++ b/src/main/java/ch/digitalfondue/jfiveparse/TreeConstructorInTable.java
@@ -243,7 +243,7 @@ final class TreeConstructorInTable {
             treeConstructor.appendToPendingTableCharactersToken(chr);
         } else {
             ResizableCharBuilder chars = treeConstructor.getPendingTableCharactersToken();
-            if (!isAllSpaceCharacters(chars)) {
+            if (!isAllSpaceCharacters(chars) && !treeConstructor.disableInTableTextForsterParenting) {
                 // TODO CHECK
 
                 treeConstructor.emitParseError();

--- a/src/test/java/ch/digitalfondue/jfiveparse/OptionParseTest.java
+++ b/src/test/java/ch/digitalfondue/jfiveparse/OptionParseTest.java
@@ -17,7 +17,7 @@ package ch.digitalfondue.jfiveparse;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,7 +32,7 @@ class OptionParseTest {
         assertEquals("<html><head></head><body>a</body></html>", JFiveParse.serialize(dw));
 
         // with option
-        Document l = JFiveParse.parse("<html><body><tr><td>a</td></tr></body>", Collections.singleton(Option.DISABLE_IGNORE_TOKEN_IN_BODY_START_TAG));
+        Document l = JFiveParse.parse("<html><body><tr><td>a</td></tr></body>", Set.of(Option.DISABLE_IGNORE_TOKEN_IN_BODY_START_TAG));
         assertEquals("<html><head></head><body><tr><td>a</td></tr></body></html>", JFiveParse.serialize(l));
     }
 
@@ -44,8 +44,27 @@ class OptionParseTest {
         assertEquals("<hr><sj-test><sj-a><sj-b></sj-b></sj-a></sj-test>", html);
 
         // with option
-        var selfClosing = JFiveParse.parseFragment("<hr /><sj-test /><sj-a><sj-b /></mj-a>", Collections.singleton(Option.INTERPRET_SELF_CLOSING_ANYTHING_ELSE));
+        var selfClosing = JFiveParse.parseFragment("<hr /><sj-test /><sj-a><sj-b /></mj-a>", Set.of(Option.INTERPRET_SELF_CLOSING_ANYTHING_ELSE));
         var selfClosingHtml = selfClosing.stream().map(s -> ((Element) s).getOuterHTML()).collect(Collectors.joining());
         assertEquals("<hr><sj-test></sj-test><sj-a><sj-b></sj-b></sj-a>", selfClosingHtml);
+    }
+
+    @Test
+    void optionDisableInTableTextFosterParenting() {
+        var res = JFiveParse.parse("""
+                <table>1
+                    <thead>12<tr>3<th>4</th>5</tr>6</thead>21
+                    <tbody>22<tr>3<td>4</td>5</tr>6</tbody>22
+                    <tfoot>32<tr>3<th>4</th>5</tr>6</tfoot>23
+                </table>
+                """, Set.of(Option.DISABLE_IN_TABLE_TEXT_FOSTER_PARENTING));
+
+        assertEquals("""
+                <table>1
+                    <thead>12<tr>3<th>4</th>5</tr>6</thead>21
+                    <tbody>22<tr>3<td>4</td>5</tr>6</tbody>22
+                    <tfoot>32<tr>3<th>4</th>5</tr>6</tfoot>23
+                </table>
+                """, res.getBody().getInnerHTML());
     }
 }

--- a/src/test/java/ch/digitalfondue/jfiveparse/TokenSaver.java
+++ b/src/test/java/ch/digitalfondue/jfiveparse/TokenSaver.java
@@ -25,7 +25,7 @@ class TokenSaver extends TreeConstructor {
     final List<Token> tokens = new ArrayList<>();
 
     public TokenSaver() {
-        super(false, false);
+        super(false, false, false);
     }
 
     @Override


### PR DESCRIPTION
this allow to keep text in the middle of table elements, implement #59 

TODO:
 - [x] add test